### PR TITLE
STACK-811 - Resolve import issue with acos_command module

### DIFF
--- a/lib/ansible/modules/network/a10/acos_command.py
+++ b/lib/ansible/modules/network/a10/acos_command.py
@@ -20,8 +20,8 @@ description:
     read from the device.
   - This module does not support running commands in configuration mode.
     Please use M(acos_config) to configure ACOS devices.
-notes:
-  - Tested against ACOS 4.1.1-P9
+version_added: '2.10'
+author: Hunter Thompson (@hthompson6)
 options:
   commands:
     description:
@@ -67,10 +67,16 @@ options:
         conditions, the interval indicates how long to wait before
         trying the command again.
     default: 1
+notes:
+  - Tested against ACOS 4.1.1-P9
 '''
 
 EXAMPLES = r'''
   tasks:
+    - name: run 'show version' command
+      acos_command:
+        commands: show version
+
     - name: run commands that requires answering a prompt
       acos_command:
         commands:
@@ -104,21 +110,6 @@ EXAMPLES = r'''
         commands: show version
         wait_for: result[0] contains ACOS
         retries: 10
-
-    - name: run multiple sequential commands on ACOS device
-      acos_command:
-        commands:
-          - command: 'configure'
-          - command: 'slb server slb1 10.43.24.17'
-          - command: 'exit'
-
-    - name: run multiple sequential commands on ACOS device with check_mode
-      acos_command:
-        commands:
-          - command: 'configure'
-          - command: 'slb server slb2 10.43.24.18'
-          - command: 'exit'
-      check_mode: 'yes'
 '''
 
 RETURN = r'''
@@ -138,6 +129,8 @@ failed_conditions:
   type: list
   sample: ['...', '...']
 '''
+
+__metaclass__ = type
 
 import time
 

--- a/lib/ansible/modules/network/a10/acos_command.py
+++ b/lib/ansible/modules/network/a10/acos_command.py
@@ -140,7 +140,6 @@ from ansible.module_utils.network.common.parsing import Conditional
 from ansible.module_utils.network.common.utils import transform_commands
 from ansible.module_utils.network.common.utils import to_lines
 from ansible.module_utils.network.a10.acos import run_commands
-from ansible.module_utils.network.a10.acos import acos_argument_spec
 
 
 def parse_commands(module, warnings):
@@ -179,7 +178,6 @@ def main():
         retries=dict(default=10, type='int'),
         interval=dict(default=1, type='int')
     )
-    argument_spec.update(acos_argument_spec)
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -2866,6 +2866,7 @@ lib/ansible/modules/network/a10/a10_virtual_server.py validate-modules:doc-defau
 lib/ansible/modules/network/a10/a10_virtual_server.py validate-modules:doc-required-mismatch
 lib/ansible/modules/network/a10/a10_virtual_server.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/network/a10/a10_virtual_server.py validate-modules:parameter-type-not-in-doc
+lib/ansible/modules/network/a10/acos_command.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/network/aci/aci_aaa_user.py validate-modules:doc-required-mismatch
 lib/ansible/modules/network/aci/aci_aaa_user_certificate.py validate-modules:doc-required-mismatch
 lib/ansible/modules/network/aci/aci_access_port_block_to_access_port.py validate-modules:doc-required-mismatch


### PR DESCRIPTION
Removed lines `from ansible.module_utils.network.a10.acos import acos_argument_spec` and `argument_spec.update(acos_argument_spec)` to resolve the import issue with the acos_command module.